### PR TITLE
Add articles endpoint

### DIFF
--- a/askapp/admin.py
+++ b/askapp/admin.py
@@ -3,10 +3,11 @@ from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from django.db import models
 from markdownx.widgets import AdminMarkdownxWidget
-from askapp.models import Profile, UserLevel, Thread, Tag, Post, ThreadLike
+from askapp.models import Profile, UserLevel, Thread, Tag, Post, ThreadLike, Token
 from django.db.models import Value, CharField
 from django.shortcuts import render
 from django.urls import path
+from django.utils.safestring import mark_safe
 from django.apps.registry import apps
 from askapp import settings
 
@@ -20,8 +21,15 @@ class ProfileInline(admin.StackedInline):
         return False
 
 
+class TokenInline(admin.StackedInline):
+    model = Token
+
+    class Media:
+        js = ('js/admin.js', )
+
+
 class CustomUserAdmin(UserAdmin):
-    inlines = (ProfileInline, )
+    inlines = (ProfileInline, TokenInline)
     ordering = ('-date_joined',)
     list_display = ('username', 'first_name', 'last_name', 'email', 'id','date_joined')
 

--- a/askapp/api.py
+++ b/askapp/api.py
@@ -1,0 +1,48 @@
+from copy import deepcopy
+import json
+from django.utils.decorators import method_decorator
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.views.generic.edit import CreateView
+from django.views.decorators.csrf import csrf_exempt
+from django.http import HttpResponse
+from askapp.views import ThreadMixin
+from askapp.models import ThreadLike, Tag
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class AddArticle(PermissionRequiredMixin, ThreadMixin, CreateView):
+    permission_required = 'askapp.add_thread'
+    raise_exception = True
+
+    def filter_tags(self, tags):
+        if not tags:
+            return None
+        db_tags = Tag.objects.get_queryset()
+        db_tags = {t.slug: t.id for t in db_tags}
+        result = [db_tags[t] for t in tags if t in db_tags]
+        return result
+
+    def get_form_kwargs(self):
+        kwargs = deepcopy(super().get_form_kwargs())
+        tag_names = self.request.POST.getlist('tags')
+        if tag_names:
+            tags = self.filter_tags(tag_names)
+            if tags:
+                kwargs['data']['tags'] = tags
+            else:
+                del kwargs['data']['tags']
+        return kwargs
+
+    def form_invalid(self, form):
+        response = json.dumps(form.errors)
+        result = HttpResponse(response, status=400, content_type='application/json')
+        return result
+
+    def form_valid(self, form):
+        super().form_valid(form)
+        points = int(self.request.POST.get('points') or 0)
+        if points:
+            tl = ThreadLike(thread=form.instance, user=self.request.user, points=points)
+            tl.save()
+        result = HttpResponse(b'{"status": "OK"}', status=200, content_type='application/json')
+        return result

--- a/askapp/backends.py
+++ b/askapp/backends.py
@@ -1,0 +1,25 @@
+"""Taken from https://github.com/jasonbeverage/django-token"""
+
+from django_token.models import Token
+
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class TokenBackend(object):
+    def authenticate(self, request, token=None):
+        """
+        Try to find a user with the given token
+        """
+        try:
+            t = Token.objects.get(key=token)
+            return t.user
+        except Token.DoesNotExist:
+            return None
+
+    def get_user(self, user_id):
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None

--- a/askapp/middleware.py
+++ b/askapp/middleware.py
@@ -8,6 +8,9 @@ except:
 
 from django.db.models import signals
 from functools import partial
+from django import http
+from django.contrib import auth
+from django.core import exceptions
 
 
 class WhodidMiddleware(MiddlewareMixin):
@@ -28,3 +31,37 @@ class WhodidMiddleware(MiddlewareMixin):
     def mark_whodid(self, user, sender, instance, **kwargs):
         if not hasattr(instance, 'modified_by_id'):
             instance.modified_by = user
+
+
+class TokenMiddleware:
+    """
+    Middleware that authenticates against a token in the http authorization
+    header.
+    """
+    get_response = None
+
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not self.get_response:
+            return exceptions.ImproperlyConfigured(
+                'Middleware called without proper initialization')
+
+        self.process_request(request)
+
+        return self.get_response(request)
+
+    def process_request(self, request):
+        auth_header = str(request.META.get('HTTP_AUTHORIZATION', '')).partition(' ')
+
+        if auth_header[0].lower() != 'token':
+            return None
+
+        # If they specified an invalid token, let them know.
+        if not auth_header[2]:
+            return http.HttpResponseBadRequest("Improperly formatted token")
+
+        user = auth.authenticate(token=auth_header[2])
+        if user:
+            request.user = user

--- a/askapp/migrations/0021_auth_token.py
+++ b/askapp/migrations/0021_auth_token.py
@@ -1,0 +1,25 @@
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Token',
+            fields=[
+                ('key', models.CharField(max_length=40, primary_key=True, serialize=False)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='token', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/askapp/models.py
+++ b/askapp/models.py
@@ -154,6 +154,34 @@ class Profile(models.Model):
         return favorite_threads(self.user)
 
 
+class Token(models.Model):
+    """
+    An access token that is associated with a user.  This is essentially the same as the token model from Django REST Framework
+    """
+    key = models.CharField(max_length=40, primary_key=True)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    created = models.DateTimeField(auto_now_add=True)
+
+    def save(self, *args, **kwargs):
+        if not self.key:
+            self.key = self.generate_key()
+        return super().save(*args, **kwargs)
+
+    def generate_key(self):
+        import binascii
+        return binascii.hexlify(os.urandom(20)).decode()
+
+    def __unicode__(self):
+        return self.key
+
+    class Meta:
+        db_table = 'django_token_token'
+
+    class Meta1:
+        app_label = 'auth'
+        db_table = 'django_token_token'
+
+
 @receiver(post_save, sender=User)
 def create_user_profile(sender, instance, created, **kwargs):
     if created or not hasattr(instance, 'profile'):

--- a/askapp/settings.py
+++ b/askapp/settings.py
@@ -64,6 +64,7 @@ MIDDLEWARE = (
     'rules_light.middleware.Middleware',
     'pagination_bootstrap.middleware.PaginationMiddleware',
     'askapp.middleware.WhodidMiddleware',
+    'askapp.middleware.TokenMiddleware',
 
 )
 
@@ -123,6 +124,7 @@ DATABASES = {
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
+    'askapp.backends.TokenBackend',
     #'allauth.account.auth_backends.AuthenticationBackend',
 ]
 SOCIALACCOUNT_ADAPTER = "askapp.socialaccount.CustomSocialAccountAdapter"

--- a/askapp/static/js/admin.js
+++ b/askapp/static/js/admin.js
@@ -1,0 +1,9 @@
+var token_field;
+function generateUID(length)
+{
+    return window.btoa(Array.from(window.crypto.getRandomValues(new Uint8Array(length * 2))).map((b) => String.fromCharCode(b)).join("")).replace(/[+/]/g, "").substring(0, length);
+}
+jQuery(document).ready(function() {
+    token_field = window.django.jQuery('#id_token-0-key')
+    token_field.after('<button onclick="token_field.val(generateUID(40)); return false">Generate new</button>')
+})

--- a/askapp/urls.py
+++ b/askapp/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls.static import static
 from django.http import HttpResponse
 
 from askapp import settings
-from askapp import views
+from askapp import views, api
 from askapp.sitemaps import sitemap_dict
 from markdownx.urls import urlpatterns as markdownx_urls
 #from registration.backends.default.urls import urlpatterns as reg_urls
@@ -41,6 +41,8 @@ urlpatterns = [
     #url(r'^accounts/', (reg_urls, 'registration', 'registration')),
     url(r'^accounts/', include('allauth.urls')),
 
+    # API
+    url(r'api/v1/article/add$', api.AddArticle.as_view(), name="api_add_article"),
 
     # authenticated users
     url(r'^profile/edit$', views.ProfileEditView.as_view(), name="profile_edit"),


### PR DESCRIPTION
Introducing REST API and authorisation by token.
There is a new section "Tokens" in the end of the user admin page. Once generated, this token can be used in HTTP "Authorization" header as "token <token_value>" in requests to endpoints.

First API endpoint is to add articles. The url is "/api/v1/article/add". Endpoint is authorised by user token. User must also have "askapp | thread | Can add thread" permission assigned in admin.

Endpoint accepts data encoded in multipart/form-data format, not JSON. Available fields are: thread_type, link, title, text, tags, points. Last two are optional, others are required. Thread_type can be one of: "LL" (link to external article), "DD" (discussion), "YT" (youtube video), "VS" (video stream).